### PR TITLE
Fix Python 3 compatability

### DIFF
--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -6,6 +6,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+from six.moves import xrange # pylint: disable=redefined-builtin
 import copy
 
 def rotmat2euler( R ):


### PR DESCRIPTION
xrange was missing from src\data_utils.py. This broke Python 3 compatability for me.